### PR TITLE
Add a conda environment file to install all dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 # Model Comparison
 
 This project includes:
- - `.R\model_comparison`: a R markdown script to download data directly from the iiasa database and create a model comparison html report including all participating models of the ECEMF Working Package 1.   
+ - `.R\model_comparison`: a R markdown script to download data directly from the IIASA database and create a model comparison html report including all participating models of the ECEMF Working Package 1.
+
+## Installation
+
+You can use Anaconda or Miniconda to setup up a combined R and Python environment to run the script:
+
+    conda env create -f environment.yaml
+
+Then, activate the conda environment:
+
+    conda activate model_comparison
+
+Use Rscript command to run render the R Markdown document using knitr
+
+    Rscript render.R
+
 
 ## How to use
  - Make sure you have R and the required libraries installed in your system. All packages can be installed via `install.packages`
@@ -19,7 +34,7 @@ install.packages(pkgs)
 ```
 
  - Rename the file "credentials_example.json" to "credentials.json" and fill it with your iiasa database credentials to download the most up to date data.
- - Set `updateResults` to true in the rmd file to download data directly from the iiasa database. The downloaded data will be saved to your local data folder. You can set the option back to FALSE afterwards (`updateResults = FALSE`) to use local data instead.   
+ - Set `updateResults` to true in the rmd file to download data directly from the iiasa database. The downloaded data will be saved to your local data folder. You can set the option back to FALSE afterwards (`updateResults = FALSE`) to use local data instead.
 
 
 ## LICENSE

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Model Comparison
 
 This project includes:
- - `.R\model_comparison`: a R markdown script to download data directly from the IIASA database and create a model comparison html report including all participating models of the ECEMF Working Package 1.
+ - `.R\model_comparison_EU28`: a R markdown script to download data directly from the IIASA database and create a model comparison html report including all participating models of the ECEMF Working Package 1.
 
 ## Installation
 
-You can use Anaconda or Miniconda to setup up a combined R and Python environment to run the script:
+You can use [Anaconda](https://www.anaconda.com/products/individual)
+or [Miniconda](https://docs.conda.io/en/latest/miniconda.html)
+to setup up a combined R and Python environment with all the dependencies needed
+to run the script:
 
     conda env create -f environment.yaml
 
@@ -13,15 +16,18 @@ Then, activate the conda environment:
 
     conda activate model_comparison
 
-Use Rscript command to run render the R Markdown document using knitr
+Rename the file `credentials_example.json` to `credentials.json` and fill it with your IIASA database credentials to download the most up to date data.
+
+Use Rscript command to run render the document using R Markdown::
 
     Rscript render.R
 
 
-## How to use
+## Installation - if you already have an R environment
+
  - Make sure you have R and the required libraries installed in your system. All packages can be installed via `install.packages`
 
-```
+```R
 pkgs <- c("reticulate",
           "rjson",
           "ggplot2",
@@ -33,7 +39,7 @@ pkgs <- c("reticulate",
 install.packages(pkgs)
 ```
 
- - Rename the file "credentials_example.json" to "credentials.json" and fill it with your iiasa database credentials to download the most up to date data.
+ - Rename the file `credentials_example.json` to `credentials.json` and fill it with your IIASA database credentials to download the most up to date data.
  - Set `updateResults` to true in the rmd file to download data directly from the iiasa database. The downloaded data will be saved to your local data folder. You can set the option back to FALSE afterwards (`updateResults = FALSE`) to use local data instead.
 
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,16 @@
+name: model_comparison_test
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.9
+  - r-dplyr
+  - r-ggplot2
+  - r-rjson
+  - r-gridextra
+  - r-svglite
+  - r-tidyr
+  - r-rmarkdown
+  - r-reticulate
+  - pyam
+prefix: /Users/wusher/miniconda3/envs/model_comparison

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,4 +1,4 @@
-name: model_comparison_test
+name: model_comparison
 channels:
   - conda-forge
   - defaults

--- a/render.R
+++ b/render.R
@@ -1,0 +1,2 @@
+library(rmarkdown)
+render('R/model_comparison_EU28.Rmd')


### PR DESCRIPTION
- Adds a conda environment file which allows easy setup of all R and Python dependencies
- Adds a one-liner, using Rscript to render the R Markdown (`Rscript render.R`)
- Adds a section to the readme describing the above