### PR TITLE
Remove the "credentials.json" file

### DIFF
--- a/R/credentials_example.json
+++ b/R/credentials_example.json
@@ -1,4 +1,0 @@
-{
-    "login": "your iiasa login", 
-    "password": "your iiasa password"
-}

--- a/R/model_comparison.Rmd
+++ b/R/model_comparison.Rmd
@@ -173,13 +173,6 @@ Regions represented in the plots:
 
 
 ```{r download_data, include=FALSE}
-if(updateResults){
-  if (file.exists("credentials.json")){
-    credentials <- fromJSON("credentials.json")
-  } else {
-    stop('To download the most up to date ECEMF data, please rename the file "credentials_example.json" to "credentials.json" and fill it with your iiasa database credentials.')
-  }
-}
 
 #create data folder
 if(!(file.exists("./data")))
@@ -193,9 +186,7 @@ if(!(file.exists("./data")))
 if (r.updateResults):
 
   import pyam
-  pyam.iiasa.set_config(r.credentials["login"], r.credentials["password"])
-  conn = pyam.iiasa.Connection()
-  conn.connect('ecemf_internal')
+  conn = pyam.iiasa.Connection('ecemf_internal')
 
   df = conn.query(
       model='*',

--- a/README.md
+++ b/README.md
@@ -16,12 +16,9 @@ Then, activate the conda environment:
 
     conda activate model_comparison
 
-Rename the file `credentials_example.json` to `credentials.json` and fill it with your IIASA database credentials to download the most up to date data.
-
 Use Rscript command to run render the document using R Markdown:
 
     Rscript render.R
-
 
 ## Installation - if you already have an R environment
 
@@ -46,11 +43,25 @@ pkgs <- c("dplyr",
 install.packages(pkgs)
 ```
 
- - Rename the file `credentials_example.json` to `credentials.json` and fill it with your IIASA database credentials to download the most up to date data.
  - Set `updateResults` to true in the rmd file to download data directly from the iiasa database. The downloaded data will be saved to your local data folder. You can set the option back to FALSE afterwards (`updateResults = FALSE`) to use local data instead.
  - Use Rscript command to run render the document using R Markdown::
 
     Rscript render.R
+
+## Set the credentials for accessing the ECEMF Scenario Explorer database
+
+This project uses the Python package [pyam](https://pyam-iamc.readthedocs.io) to query
+scenario data directly from the IIASA database infrastructure.
+
+Please run the following script once in a Python console:
+
+```python
+import pyam
+pyam.iiasa.set_config("<username>", "<password>")
+```
+
+Refer to this [tutorial](https://pyam-iamc.readthedocs.io/en/stable/tutorials/iiasa_dbs.html)
+for more information!
 
 ## LICENSE
 This program is free software: you can redistribute it and/or modify it under the terms of the **GNU Affero General Public License** as published by the Free Software Foundation, **version 3** of the License or later. You can see the LICENSE details in https://www.gnu.org/licenses/agpl.txt


### PR DESCRIPTION
It is not good practice to store credentials in a plain-text file in a git project. pyam supports storing the credentials in another location on a machine.

This PR refactors the code and updates the Readme to use the ``pyam.iiasa.set_config()`` feature as intended.